### PR TITLE
Add CI workflow for CRI-O deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+      - name: Start minikube with CRI-O
+        uses: medyagh/setup-minikube@v0.0.16
+        with:
+          driver: docker
+          container-runtime: cri-o
+      - name: Start local registry
+        run: |
+          docker run -d -p 5000:5000 --name registry registry:2
+      - name: Deploy operator
+        run: EMULATED_MODE=enabled make deploy-k8s


### PR DESCRIPTION
## Summary
- add `.github/workflows/ci.yml` for CI

## Testing
- `go test ./... -run TestNonExistent`
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_684d5e603b24832f90f6ce60351bf107